### PR TITLE
Switch to SQLite storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /tmp
 node_modules
 /dist
-.astro
+data/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,10 @@
         "@astrojs/react": "^3.0.7",
         "@astrojs/tailwind": "^5.0.3",
         "astro": "^4.0.3",
+        "better-sqlite3": "^12.2.0",
         "canvas": "^2.11.2",
+        "gray-matter": "^4.0.3",
+        "marked": "^16.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "tailwindcss": "^3.3.6"
@@ -3189,6 +3192,40 @@
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz",
+      "integrity": "sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3199,6 +3236,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/boxen": {
@@ -3274,6 +3331,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/camelcase": {
@@ -3658,6 +3739,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -3767,6 +3857,15 @@
       "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -3874,6 +3973,15 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3916,6 +4024,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -4001,6 +4115,12 @@
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -4149,6 +4269,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
@@ -4470,6 +4596,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
@@ -4495,6 +4641,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -4952,6 +5104,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.0.0.tgz",
+      "integrity": "sha512-MUKMXDjsD/eptB7GPzxo4xcnLS6oo7/RHimUMHEDRhUooPwmN9BEpMl7AEOJv3bmso169wHI2wUF9VQgL7zfmA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -5815,6 +5979,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -5867,6 +6040,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/mrmime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
@@ -5917,6 +6096,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/neotraverse": {
       "version": "0.6.18",
       "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
@@ -5937,6 +6122,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-fetch": {
@@ -6448,6 +6657,84 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/preferred-pm": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-4.0.0.tgz",
@@ -6503,6 +6790,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6522,6 +6819,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -7371,6 +7683,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -7469,6 +7790,40 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/minipass": {
@@ -7583,6 +7938,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-fest": {
       "version": "4.30.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "@astrojs/react": "^3.0.7",
     "@astrojs/tailwind": "^5.0.3",
     "astro": "^4.0.3",
+    "better-sqlite3": "^12.2.0",
     "canvas": "^2.11.2",
+    "gray-matter": "^4.0.3",
+    "marked": "^16.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwindcss": "^3.3.6"

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -1,14 +1,11 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllPosts } from '../db';
 
-// Get all posts from content collection
-const allPosts = await getCollection('posts');
+// Get all posts from database
+const allPosts = getAllPosts();
 
 // Sort posts by date
-const sortedPosts = allPosts
-  .sort((a, b) => 
-    b.data.publishDate.getTime() - a.data.publishDate.getTime()
-  );
+const sortedPosts = allPosts;
 
 ---
 
@@ -16,18 +13,18 @@ const sortedPosts = allPosts
   {sortedPosts.map(post => (
     <div class="flex-shrink-0 min-w-full">
       <div class="flex items-center justify-center gap-2 text-center">
-        <a 
-          href={`/${post.data.profile}/${post.data.permalink}`}
+        <a
+          href={`/${post.profilePermalink}/${post.permalink}`}
           class="text-gray-200 hover:text-white transition-colors"
         >
-          {post.data.title}
+          {post.title}
         </a>
         <span class="text-gray-400">by</span>
-        <a 
-          href={`/${post.data.profile}`}
+        <a
+          href={`/${post.profilePermalink}`}
           class="text-red-500 hover:text-red-400 transition-colors"
         >
-          {post.data.profile === 'the-source' ? 'The Source' : post.data.profile}
+          {post.profilePermalink === 'the-source' ? 'The Source' : post.profilePermalink}
         </a>
       </div>
     </div>

--- a/src/components/ProfilePosts.astro
+++ b/src/components/ProfilePosts.astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getPostsByProfile } from '../db';
 
 interface Props {
   profile: string;
@@ -8,23 +8,20 @@ interface Props {
 const { profile } = Astro.props;
 
 // Get posts for this profile
-const posts = await getCollection('posts', post => post.data.profile === profile);
-const sortedPosts = posts
-  .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
-  .slice(0, 10);
+const sortedPosts = getPostsByProfile(profile).slice(0, 10);
 ---
 
 <div class="space-y-4">
   {sortedPosts.map(post => (
     <div class="border-l-2 border-red-500 pl-4">
-      <a 
-        href={`/${post.data.profile}/${post.data.permalink}`} 
+      <a
+        href={`/${post.profilePermalink}/${post.permalink}`}
         class="text-lg hover:text-red-500 transition-colors"
       >
-        {post.data.title}
+        {post.title}
       </a>
       <div class="text-gray-400 text-sm mt-1">
-        {post.data.publishDate.toLocaleDateString('en-US', {
+        {new Date(post.publish_date).toLocaleDateString('en-US', {
           year: 'numeric',
           month: 'long',
           day: 'numeric'

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,125 @@
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+const DB_PATH = path.join(process.cwd(), 'data', 'database.sqlite');
+
+fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+
+const db = new Database(DB_PATH);
+
+export function initDatabase() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS profiles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      permalink TEXT UNIQUE NOT NULL,
+      bio TEXT
+    );
+    CREATE TABLE IF NOT EXISTS posts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      profile_id INTEGER NOT NULL,
+      permalink TEXT NOT NULL,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      publish_date TEXT NOT NULL,
+      preview INTEGER DEFAULT 1,
+      FOREIGN KEY(profile_id) REFERENCES profiles(id),
+      UNIQUE(profile_id, permalink)
+    );
+    CREATE TABLE IF NOT EXISTS comments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      post_id INTEGER NOT NULL,
+      author TEXT,
+      content TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(post_id) REFERENCES posts(id)
+    );
+  `);
+}
+
+initDatabase();
+
+function seedFromContent() {
+  const profileCount = db.prepare('SELECT COUNT(*) as count FROM profiles').get().count;
+  if (profileCount > 0) return;
+
+  const profilesDir = path.join(process.cwd(), 'src', 'content', 'profiles');
+  const postsDir = path.join(process.cwd(), 'src', 'content', 'posts');
+
+  const insertProfile = db.prepare('INSERT INTO profiles (name, permalink, bio) VALUES (?, ?, ?)');
+  const insertPost = db.prepare('INSERT INTO posts (profile_id, permalink, title, content, publish_date, preview) VALUES (?, ?, ?, ?, ?, ?)');
+
+  const profileFiles = fs.readdirSync(profilesDir).filter(f => f.endsWith('.md'));
+  const profilesMap: Record<string, number> = {};
+
+  for (const file of profileFiles) {
+    const fullPath = path.join(profilesDir, file);
+    const { data } = matter(fs.readFileSync(fullPath, 'utf8'));
+    const info = insertProfile.run(data.name || data.title, data.permalink, data.bio || '');
+    profilesMap[data.permalink] = info.lastInsertRowid as number;
+  }
+
+  const profileDirs = fs.readdirSync(postsDir);
+  for (const dir of profileDirs) {
+    const fullDir = path.join(postsDir, dir);
+    if (!fs.statSync(fullDir).isDirectory()) continue;
+    const files = fs.readdirSync(fullDir).filter(f => f.endsWith('.md'));
+    for (const f of files) {
+      const p = path.join(fullDir, f);
+      const { data, content } = matter(fs.readFileSync(p, 'utf8'));
+      const profileId = profilesMap[data.profile];
+      if (!profileId) continue;
+      const dateStr = (data.publishDate instanceof Date ? data.publishDate.toISOString() : data.publishDate);
+      insertPost.run(profileId, data.permalink, data.title, content.trim(), dateStr, data.preview === false ? 0 : 1);
+    }
+  }
+}
+
+seedFromContent();
+
+export function getAllProfiles() {
+  return db.prepare('SELECT * FROM profiles ORDER BY name').all();
+}
+
+export function getProfile(permalink: string) {
+  return db.prepare('SELECT * FROM profiles WHERE permalink = ?').get(permalink);
+}
+
+export function getAllPosts() {
+  return db.prepare(`
+    SELECT posts.*, profiles.permalink as profilePermalink, profiles.name as profileName
+    FROM posts JOIN profiles ON posts.profile_id = profiles.id
+    ORDER BY datetime(publish_date) DESC
+  `).all();
+}
+
+export function getPostsByProfile(permalink: string) {
+  return db.prepare(`
+    SELECT posts.*, profiles.permalink as profilePermalink, profiles.name as profileName
+    FROM posts JOIN profiles ON posts.profile_id = profiles.id
+    WHERE profiles.permalink = ?
+    ORDER BY datetime(publish_date) DESC
+  `).all(permalink);
+}
+
+export function getPost(profilePermalink: string, postPermalink: string) {
+  return db.prepare(`
+    SELECT posts.*, profiles.permalink as profilePermalink, profiles.name as profileName
+    FROM posts JOIN profiles ON posts.profile_id = profiles.id
+    WHERE profiles.permalink = ? AND posts.permalink = ?
+  `).get(profilePermalink, postPermalink);
+}
+
+export function getComments(profilePermalink: string, postPermalink: string) {
+  return db.prepare(`
+    SELECT c.* FROM comments c
+    JOIN posts p ON c.post_id = p.id
+    JOIN profiles prof ON p.profile_id = prof.id
+    WHERE prof.permalink = ? AND p.permalink = ?
+    ORDER BY datetime(c.created_at) ASC
+  `).all(profilePermalink, postPermalink);
+}
+
+export default db;

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -6,29 +6,29 @@ import SharePost from '../components/SharePost.astro';
 import config from '../../astro.config.mjs';
 
 const { post, visiblePercent = 60 } = Astro.props;
-const preview = post.data.preview !== undefined ? post.data.preview : true;
-const publishDate = post.data.publishDate;
+const preview = post.preview !== undefined ? post.preview : true;
+const publishDate = new Date(post.publish_date);
 const currentPath = Astro.url.pathname.replace(/\/$/, '');
 const canonicalURL = new URL(currentPath, Astro.site).toString();
 
 // Generate social image URL
 const pathParts = currentPath.split('/').filter(Boolean);
-const socialImageUrl = new URL(`/api/social-image?permalink=${post.data.permalink}`, Astro.site).toString();
+const socialImageUrl = new URL(`/api/social-image?permalink=${post.permalink}`, Astro.site).toString();
 
 const visibleHeight = "500px"; // (visiblePercent / 100) * 100;
 
 ---
 
-<Layout title={`${post.data.title}${config.titlePostfix}`}>
-  <meta property="og:title" content={`${post.data.title}${config.titlePostfix}`} />
-  <meta property="twitter:title" content={`${post.data.title}${config.titlePostfix}`} />
+<Layout title={`${post.title}${config.titlePostfix}`}>
+  <meta property="og:title" content={`${post.title}${config.titlePostfix}`} />
+  <meta property="twitter:title" content={`${post.title}${config.titlePostfix}`} />
 
   <article class="max-w-3xl mx-auto px-4 py-12">
-    <h1 class="text-3xl font-bold mb-4">{post.data.title}</h1>
+    <h1 class="text-3xl font-bold mb-4">{post.title}</h1>
     <div class="flex items-center gap-2 text-gray-400 mb-8">
       <span>by</span>
-      <a href={`/${post.data.profile}`} class="text-red-500 hover:text-red-400">
-        {post.data.profile === 'the-source' ? 'The Source' : post.data.profile}
+      <a href={`/${post.profilePermalink}`} class="text-red-500 hover:text-red-400">
+        {post.profilePermalink === 'the-source' ? 'The Source' : post.profilePermalink}
       </a>
       <span>•</span>
       <time datetime={publishDate.toISOString()}>
@@ -44,7 +44,7 @@ const visibleHeight = "500px"; // (visiblePercent / 100) * 100;
         <slot />
         {preview && (
           <div class="text-center mt-8">
-            <a href={`/${post.data.profile}/${post.data.permalink}`} class="text-red-500 hover:text-red-400">
+            <a href={`/${post.profilePermalink}/${post.permalink}`} class="text-red-500 hover:text-red-400">
               Read More →
             </a>
           </div>
@@ -53,7 +53,7 @@ const visibleHeight = "500px"; // (visiblePercent / 100) * 100;
     </div>
     
     <div class="mt-12 space-y-8">
-      <SharePost url={canonicalURL} title={post.data.title} />
+      <SharePost url={canonicalURL} title={post.title} />
       <JoinMission />
     </div>
   </article>

--- a/src/pages/[profile].astro
+++ b/src/pages/[profile].astro
@@ -1,13 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import ProfilePosts from '../components/ProfilePosts.astro';
-import { getCollection } from 'astro:content';
+import { getAllProfiles } from '../db';
 
 export async function getStaticPaths() {
-  const profiles = await getCollection('profiles');
+  const profiles = getAllProfiles();
   return profiles.map(profile => ({
-    params: { profile: profile.data.permalink },
-    props: { profile: profile.data }
+    params: { profile: profile.permalink },
+    props: { profile }
   }));
 }
 

--- a/src/pages/[profile]/[post].astro
+++ b/src/pages/[profile]/[post].astro
@@ -1,33 +1,37 @@
 ---
-import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 import PostLayout from '../../layouts/PostLayout.astro';
+import { marked } from 'marked';
+import { getAllPosts, getPost } from '../../db';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('posts');
+  const posts = getAllPosts();
   return posts.map(post => ({
-    params: { 
-      profile: post.data.profile,
-      post: post.data.permalink
+    params: {
+      profile: post.profilePermalink,
+      post: post.permalink
     },
-    props: { post }
+    props: {
+      profile: post.profilePermalink,
+      postPermalink: post.permalink
+    }
   }));
 }
 
-const { post } = Astro.props;
-const { Content } = await post.render();
+const { profile, postPermalink } = Astro.props;
+const post = getPost(profile, postPermalink);
 ---
 
-<Layout title={`${post.data.title} - Izvir`}>
+<Layout title={`${post.title} - Izvir`}>
   <head>
     <!-- Social Media Meta Tags -->
-    <meta property="og:title" content={post.data.title} />
-    <meta property="og:description" content={post.data.description || `A post on Izvir by ${post.data.profile}`} />
+    <meta property="og:title" content={post.title} />
+    <meta property="og:description" content={`A post on Izvir by ${post.profilePermalink}`} />
     <meta property="og:url" content={Astro.url} />
     <meta name="twitter:card" content="summary_large_image" />
   </head>
-  
+
   <PostLayout post={post} preview={false}>
-    <Content />
+    <div set:html={marked.parse(post.content)} />
   </PostLayout>
 </Layout>

--- a/src/pages/[profile]/index.astro
+++ b/src/pages/[profile]/index.astro
@@ -1,40 +1,31 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import ProfilePosts from '../../components/ProfilePosts.astro';
-import { getCollection } from 'astro:content';
+import { getAllProfiles } from '../../db';
 
 export async function getStaticPaths() {
-  const profiles = await getCollection('profiles');
+  const profiles = getAllProfiles();
   return profiles.map(profile => ({
-    params: { profile: profile.data.permalink },
+    params: { profile: profile.permalink },
     props: { profile }
   }));
 }
 
 const { profile } = Astro.props;
-const { Content } = await profile.render();
-
-// Get all posts for this profile
-const posts = await getCollection('posts');
-const profilePosts = posts
-  .filter(post => post.data.profile === profile.data.permalink)
-  .sort((a, b) => 
-    new Date(b.data.publishDate).getTime() - new Date(a.data.publishDate).getTime()
-  );
 ---
 
-<Layout title={`${profile.data.name} - Izvir`}>
+<Layout title={`${profile.name} - Izvir`}>
   <div class="max-w-4xl mx-auto px-4 py-12">
     <header class="mb-12 text-center">
-      <h1 class="text-4xl font-bold mb-4">{profile.data.name}</h1>
+      <h1 class="text-4xl font-bold mb-4">{profile.name}</h1>
       <div class="text-gray-400 max-w-2xl mx-auto prose prose-invert">
-        <Content />
+        {profile.bio}
       </div>
     </header>
 
     <div class="mb-8">
       <h2 class="text-2xl font-semibold mb-6">All Posts</h2>
-      <ProfilePosts profile={profile.data.permalink} />
+      <ProfilePosts profile={profile.permalink} />
     </div>
   </div>
 </Layout>

--- a/src/pages/api/share-image.ts
+++ b/src/pages/api/share-image.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { createCanvas } from 'canvas';
-import { getCollection } from 'astro:content';
+import { getPost } from '../../db';
 
 export const GET: APIRoute = async ({ url }) => {
   try {
@@ -10,11 +10,9 @@ export const GET: APIRoute = async ({ url }) => {
       return new Response('Post permalink is required', { status: 400 });
     }
 
-    // Get all posts and find the matching one
-    const posts = await getCollection('posts');
     // Extract profile and post slug from the permalink
     const [profile, postSlug] = permalink.split('/');
-    const post = posts.find(p => p.data.profile === profile && p.slug === postSlug);
+    const post = getPost(profile, postSlug);
     
     if (!post) {
       return new Response('Post not found', { status: 404 });
@@ -44,7 +42,7 @@ export const GET: APIRoute = async ({ url }) => {
     // Add profile name
     ctx.fillStyle = '#888888';
     ctx.font = '32px Arial';
-    ctx.fillText(`@${post.data.profile}`, width / 2, 150);
+    ctx.fillText(`@${post.profilePermalink}`, width / 2, 150);
 
     // Add post title with gradient
     const titleGradient = ctx.createLinearGradient(0, height / 2 - 100, 0, height / 2 + 100);
@@ -54,7 +52,7 @@ export const GET: APIRoute = async ({ url }) => {
     ctx.font = 'bold 64px Arial';
 
     // Word wrap title
-    const words = post.data.title.split(' ');
+    const words = post.title.split(' ');
     let line = '';
     let lines = [];
     const maxWidth = width - 200;
@@ -79,7 +77,7 @@ export const GET: APIRoute = async ({ url }) => {
     });
 
     // Add publish date at the bottom
-    const publishDate = new Date(post.data.publishDate).toLocaleDateString('en-US', {
+    const publishDate = new Date(post.publish_date).toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric'

--- a/src/pages/api/social-image.ts
+++ b/src/pages/api/social-image.ts
@@ -1,23 +1,23 @@
 import type { APIRoute } from 'astro';
-import { getCollection } from 'astro:content';
+import { getAllPosts, getAllProfiles, getPost, getProfile } from '../../db';
 import { generateSocialImage } from '../../utils/socialImage';
 import { imageCache } from '../../utils/imageCache';
 
 export async function getStaticPaths() {
-    const posts = await getCollection('posts');
-    const profiles = await getCollection('profiles');
+    const posts = getAllPosts();
+    const profiles = getAllProfiles();
     
     // For posts: /api/social-image/[profile]/[post]
     const postPaths = posts.map(post => ({
-        params: { 
-            permalink: `${post.data.profile}/${post.data.permalink}`
+        params: {
+            permalink: `${post.profilePermalink}/${post.permalink}`
         }
     }));
     
     // For profiles: /api/social-image/[profile]
     const profilePaths = profiles.map(profile => ({
-        params: { 
-            permalink: profile.data.permalink
+        params: {
+            permalink: profile.permalink
         }
     }));
 
@@ -52,15 +52,14 @@ export const GET: APIRoute = async ({ request }) => {
         // Check if this is a profile or a post
         if (!permalink.includes('/')) {
             // This is a profile
-            const profiles = await getCollection('profiles');
-            const profile = profiles.find(p => p.data.permalink === permalink);
+            const profile = getProfile(permalink);
             
             if (!profile) {
                 return new Response('Profile not found', { status: 404 });
             }
 
             const image = await generateSocialImage(
-                profile.data.name,
+                profile.name,
                 'Izvir Social Profile'
             );
 
@@ -75,17 +74,16 @@ export const GET: APIRoute = async ({ request }) => {
             });
         } else {
             // This is a post
-            const posts = await getCollection('posts');
             const [profile, postPermalink] = permalink.split('/');
-            const post = posts.find(p => p.data.profile === profile && p.data.permalink === postPermalink);
+            const post = getPost(profile, postPermalink);
             
             if (!post) {
                 return new Response('Post not found', { status: 404 });
             }
 
             const image = await generateSocialImage(
-                post.data.title,
-                post.data.profile || 'Izvir Social'
+                post.title,
+                post.profilePermalink || 'Izvir Social'
             );
 
             // Cache the image


### PR DESCRIPTION
## Summary
- add `better-sqlite3`, `gray-matter` and `marked`
- create `src/db.ts` to initialize SQLite DB and seed from existing markdown
- update components and pages to pull data from SQLite instead of content collections
- adjust API routes for posts and profiles
- ignore generated database files

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68664e234078832a87cde900dc2c46ec